### PR TITLE
Fix two false positives for Zip regex

### DIFF
--- a/src/games/zipgame.ts
+++ b/src/games/zipgame.ts
@@ -20,20 +20,21 @@ const zipParseOptionsArr: ZipParseOptions[] = [
     {   // Generic (logged-out and most languages)
         /*
 
-        * Zip\D*?(\d+) - matches the Zip number section
-            * Zip - matches name
-            * \D*? - matches text between name and number
+        * ^\p{Cf}? - matches format character at the start of the line
+        * Zip\D*(\d+) - matches the Zip number section
+            * Zip - matches name of game
+            * \D* - matches text between name and number
             * (\d+) - captures actual number
-        * \D+? - matches any text between previous and the time
+        * \D+ - matches any text between previous and the time
         * (\d+):(\d{2}) - captures the minutes and seconds
-        * (?:\D+?(\d*)\D*?(🛑|🟢))? - optional non-capturing group for backtracks
-            * \D+? - matches text before backtracks
+        * (?:\D+(\d*)\D*?(🛑|🟢))? - optional non-capturing group for backtracks
+            * \D+ - matches text before backtracks
             * (\d*) - captures the backtrack count (or empty if none)
             * \D*? - matches text after backtrack count (if any)
             * (🛑|🟢) - captures colored emoji (🛑 iff backtracks)
         
         */
-        regex: /^Zip\D*?(\d+)\D+?(\d+):(\d{2})(?:\D+?(\d*)\D*?(🛑|🟢))?/mu,
+        regex: /^\p{Cf}?Zip\D*(\d+)\D+(\d+):(\d{2})(?:\D+(\d*)\D*?(🛑|🟢))?/mu,
         groups: {
             zipNumber: 1,
             minutes: 2,

--- a/src/games/zipgame.ts
+++ b/src/games/zipgame.ts
@@ -24,9 +24,8 @@ const zipParseOptionsArr: ZipParseOptions[] = [
             * Zip - matches name
             * \D*? - matches text between name and number
             * (\d+) - captures actual number
-        * [\S\s]*? - matches any text between previous and the time
-        * (\d+):(\d+) - captures the minutes and seconds
-        * \D*? - matches all text until the backtracks
+        * \D+? - matches any text between previous and the time
+        * (\d+):(\d{2}) - captures the minutes and seconds
         * (?:\D*?(\d*)\D*?(🛑|🟢))? - optional non-capturing group for backtracks
             * \D*? - matches text before backtracks
             * (\d*) - captures the backtrack count (or empty if none)
@@ -34,7 +33,7 @@ const zipParseOptionsArr: ZipParseOptions[] = [
             * (🛑|🟢) - captures colored emoji (🛑 iff backtracks)
         
         */
-        regex: /^Zip\D*?(\d+)[\S\s]*?(\d+):(\d{2})\D*?(?:\D*?(\d*)\D*?(🛑|🟢))?/mu,
+        regex: /^Zip\D*?(\d+)\D+?(\d+):(\d{2})(?:\D*?(\d*)\D*?(🛑|🟢))?/mu,
         groups: {
             zipNumber: 1,
             minutes: 2,

--- a/src/games/zipgame.ts
+++ b/src/games/zipgame.ts
@@ -27,13 +27,13 @@ const zipParseOptionsArr: ZipParseOptions[] = [
         * \D+? - matches any text between previous and the time
         * (\d+):(\d{2}) - captures the minutes and seconds
         * (?:\D*?(\d*)\D*?(🛑|🟢))? - optional non-capturing group for backtracks
-            * \D*? - matches text before backtracks
+            * \D+? - matches text before backtracks
             * (\d*) - captures the backtrack count (or empty if none)
             * \D*? - matches text after backtrack count (if any)
             * (🛑|🟢) - captures colored emoji (🛑 iff backtracks)
         
         */
-        regex: /^Zip\D*?(\d+)\D+?(\d+):(\d{2})(?:\D*?(\d*)\D*?(🛑|🟢))?/mu,
+        regex: /^Zip\D*?(\d+)\D+?(\d+):(\d{2})(?:\D+?(\d*)\D*?(🛑|🟢))?/mu,
         groups: {
             zipNumber: 1,
             minutes: 2,

--- a/src/games/zipgame.ts
+++ b/src/games/zipgame.ts
@@ -26,7 +26,7 @@ const zipParseOptionsArr: ZipParseOptions[] = [
             * (\d+) - captures actual number
         * \D+? - matches any text between previous and the time
         * (\d+):(\d{2}) - captures the minutes and seconds
-        * (?:\D*?(\d*)\D*?(🛑|🟢))? - optional non-capturing group for backtracks
+        * (?:\D+?(\d*)\D*?(🛑|🟢))? - optional non-capturing group for backtracks
             * \D+? - matches text before backtracks
             * (\d*) - captures the backtrack count (or empty if none)
             * \D*? - matches text after backtrack count (if any)


### PR DESCRIPTION
Just noticed this issue. I tested the modified regex on a website, and it works the same for valid submissions.
- Removes two edge cases where the Regex should not match.
- Updates documentation comment for the regex.